### PR TITLE
Throw warning if index file already exists, add --force option to overwrite

### DIFF
--- a/rsidx/cli.py
+++ b/rsidx/cli.py
@@ -15,6 +15,10 @@ import rsidx
 def index_subparser(subparsers):
     cli = subparsers.add_parser('index')
     cli.add_argument(
+        '-f', '--force', action='store_true', help='force overwrite of index '
+        'file if it already exists'
+    )
+    cli.add_argument(
         '-c', '--cache-size', type=int, metavar='C', help='modify default '
         'sqlite3 cache size (in KiB)'
     )

--- a/rsidx/cli.py
+++ b/rsidx/cli.py
@@ -27,7 +27,7 @@ def index_subparser(subparsers):
         'memory map mode and specify mmap_size (in bytes)'
     )
     cli.add_argument('vcf', help='sorted VCF file to index')
-    cli.add_argument('dbfile', help='file to which sqlite3 db will be written')
+    cli.add_argument('idx', help='index file to create')
 
 
 def search_subparser(subparsers):
@@ -38,7 +38,7 @@ def search_subparser(subparsers):
         'default is terminal (stdout)'
     )
     cli.add_argument('vcf', help='sorted and indexed VCF file')
-    cli.add_argument('dbfile', help='rsidx index')
+    cli.add_argument('idx', help='rsidx index file')
     cli.add_argument('rsid', nargs='+', help='rsID(s) to search')
 
 

--- a/rsidx/index.py
+++ b/rsidx/index.py
@@ -50,12 +50,12 @@ def index(dbconn, vcffh, cache_size=None, mmap_size=None, logint=1e6):
 
 
 def main(args):
-    if os.path.exists(args.dbfile):
-        message = 'WARNING: index file "{:s}" exists'.format(args.dbfile)
+    if os.path.exists(args.idx):
+        message = 'WARNING: index file "{:s}" exists'.format(args.idx)
         if args.force:
             message += ', overwriting'
             try:
-                os.unlink(args.dbfile)
+                os.unlink(args.idx)
             except FileNotFoundError:  # prevent exploits  # pragma: no cover
                 pass
         else:
@@ -64,6 +64,6 @@ def main(args):
         if not args.force:
             raise SystemExit
     with rsidx.open(args.vcf, 'r') as vcffh:
-        with sqlite3.connect(args.dbfile) as dbconn:
+        with sqlite3.connect(args.idx) as dbconn:
             index(dbconn, vcffh, cache_size=args.cache_size,
                   mmap_size=args.mmap_size)

--- a/rsidx/index.py
+++ b/rsidx/index.py
@@ -7,6 +7,7 @@
 # and is licensed under the BSD license: see LICENSE.txt.
 # -----------------------------------------------------------------------------
 
+import os
 import rsidx
 import sqlite3
 import sys
@@ -49,6 +50,19 @@ def index(dbconn, vcffh, cache_size=None, mmap_size=None, logint=1e6):
 
 
 def main(args):
+    if os.path.exists(args.dbfile):
+        message = 'WARNING: index file "{:s}" exists'.format(args.dbfile)
+        if args.force:
+            message += ', overwriting'
+            try:
+                os.unlink(args.dbfile)
+            except FileNotFoundError:  # prevent exploits  # pragma: no cover
+                pass
+        else:
+            message += ', stubbornly refusing to proceed'
+        print('[rsidx]', message, file=sys.stderr)
+        if not args.force:
+            raise SystemExit
     with rsidx.open(args.vcf, 'r') as vcffh:
         with sqlite3.connect(args.dbfile) as dbconn:
             index(dbconn, vcffh, cache_size=args.cache_size,

--- a/rsidx/search.py
+++ b/rsidx/search.py
@@ -56,7 +56,7 @@ def search(rsidlist, dbconn, vcffile, header=False):
 
 
 def main(args):
-    conn = sqlite3.connect(args.dbfile)
+    conn = sqlite3.connect(args.idx)
     with rsidx.open(args.out, 'w') as out:
         for line in search(args.rsid, conn, args.vcf, header=args.header):
             print(line, end='', file=out)

--- a/rsidx/tests/__init__.py
+++ b/rsidx/tests/__init__.py
@@ -7,11 +7,23 @@
 # and is licensed under the BSD license: see LICENSE.txt.
 # -----------------------------------------------------------------------------
 
+from contextlib import contextmanager
 import os
 from pkg_resources import resource_filename
+from tempfile import NamedTemporaryFile
 
 
 def data_file(path):
     pathparts = path.split('/')
     relpath = os.path.join('tests', 'data', *pathparts)
     return resource_filename('rsidx', relpath)
+
+
+@contextmanager
+def TempFileName(*args, **kwds):
+    with NamedTemporaryFile(*args, **kwds) as tf:
+        os.unlink(tf.name)
+        try:
+            yield tf.name
+        finally:
+            pass

--- a/rsidx/tests/test_index.py
+++ b/rsidx/tests/test_index.py
@@ -92,11 +92,11 @@ def test_index_multi_rsids():
 
 @pytest.mark.parametrize('mainfunc', [rsidx.index.main, rsidx.__main__.main])
 def test_index_cli(mainfunc):
-    with TempFileName(suffix='.rsidx') as dbfile:
-        arglist = ['index', data_file('chr17-sample.vcf.gz'), dbfile]
+    with TempFileName(suffix='.rsidx') as idxfile:
+        arglist = ['index', data_file('chr17-sample.vcf.gz'), idxfile]
         args = rsidx.cli.get_parser().parse_args(arglist)
         mainfunc(args)
-        conn = sqlite3.connect(dbfile)
+        conn = sqlite3.connect(idxfile)
         c = conn.cursor()
         query = (
             'SELECT * FROM rsid_to_coord WHERE rsid IN '
@@ -111,10 +111,10 @@ def test_index_cli(mainfunc):
 
 def test_index_multi(capsys):
     vcffile = data_file('chr9-multi.vcf.gz')
-    with TempFileName(suffix='.rsidx') as dbfile, rsidx.open(vcffile, 'r') as vcffh:
-        with sqlite3.connect(dbfile) as dbconn:
+    with TempFileName(suffix='.rsidx') as idxfile, rsidx.open(vcffile, 'r') as vcffh:
+        with sqlite3.connect(idxfile) as dbconn:
             rsidx.index.index(dbconn, vcffh)
-        arglist = ['search', vcffile, dbfile, 'rs60995877']
+        arglist = ['search', vcffile, idxfile, 'rs60995877']
         args = rsidx.cli.get_parser().parse_args(arglist)
         rsidx.search.main(args)
     terminal = capsys.readouterr()
@@ -122,8 +122,8 @@ def test_index_multi(capsys):
 
 
 def test_index_no_force_reindex(capsys):
-    with TempFileName(suffix='.rsidx') as dbfile:
-        arglist = ['index', data_file('chr9-multi.vcf.gz'), dbfile]
+    with TempFileName(suffix='.rsidx') as idxfile:
+        arglist = ['index', data_file('chr9-multi.vcf.gz'), idxfile]
         args = rsidx.cli.get_parser().parse_args(arglist)
         rsidx.index.main(args)
         with pytest.raises(SystemExit):
@@ -133,8 +133,8 @@ def test_index_no_force_reindex(capsys):
 
 
 def test_index_force_reindex(capsys):
-    with TempFileName(suffix='.rsidx') as dbfile:
-        arglist = ['index', '--force', data_file('chr9-multi.vcf.gz'), dbfile]
+    with TempFileName(suffix='.rsidx') as idxfile:
+        arglist = ['index', '--force', data_file('chr9-multi.vcf.gz'), idxfile]
         args = rsidx.cli.get_parser().parse_args(arglist)
         rsidx.index.main(args)
         rsidx.index.main(args)


### PR DESCRIPTION
Currently, `rsidx index` fails if the specified index file already exists. This update will terminate execution with a warning if the file already exists, or alternatively provides a new `--force` flag to overwrite the file. Closes #3.